### PR TITLE
feat: 增加model参数 去更好的支持非OpenAI的API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ iwhat ${word}
 
 1. 能正常联网的环境或 proxy
 2. 如果你遇到了墙需要用 Cloudflare Workers 替换 api_base 请使用 `--api_base ${url}` 来替换。**请注意，此处你输入的api应该是"`https://xxxx/v1`"的字样，域名需要用引号包裹**
-3. 也可以 `export OPENAI_BASE_URL=xxxxx`
+3. 也可以 `export OPENAI_API_BASE=xxxxx`
+4. 如果使用非OpenAI的接口,需要设置对应的 url 和 model
+
+    i. export OPENAI_API_BASE=xxxxx 或者 iwhat ${word} --api_base xxxx
+
+    ii. export OPENAI_API_BASE=xxxxx 或者 iwhat ${word} --model xxxx
+
 
 ## 赞赏
 谢谢就够了

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url="https://github.com/yihong0618/iWhat",
     license="MIT",
     version="0.2.1",
-    install_requires=["rich", "openai==1.1.1"],
+    install_requires=["rich", "openai==1.56.0"],
     entry_points={
         "console_scripts": ["iwhat = what.cli:main"],
     },

--- a/what/cli.py
+++ b/what/cli.py
@@ -29,6 +29,13 @@ def main():
     parser.add_argument(
         "--en", dest="en", action="store_true", help="If use English to answer"
     )
+    
+    parser.add_argument(
+        "--model",
+        dest="model",
+        type=str,
+        help="Specify the model to use. Example: 'gpt-3.5-turbo' or 'gpt-4'. Default is 'gpt-3.5-turbo'."
+    )
 
     options = parser.parse_args()
     PROXY = options.proxy
@@ -40,7 +47,11 @@ def main():
     if not OPENAI_API_KEY:
         raise Exception("OpenAI API key not provided, please google how to obtain it")
 
-    what = What(options.what, is_en=options.en, api_base=options.api_base)
+    OPENAI_API_BASE = options.api_base or env.get("OPENAI_API_BASE")
+
+    MODEL = options.model or env.get("IWHAT_MODEL") or "gpt-3.5-turbo"
+
+    what = What(options.what, is_en=options.en, api_base=OPENAI_API_BASE, api_key=OPENAI_API_KEY, model=MODEL)
     what.show_what()
 
 

--- a/what/what.py
+++ b/what/what.py
@@ -10,16 +10,11 @@ from openai import OpenAI
 
 
 class What:
-    def __init__(self, what, is_en=False, api_base=None):
-        self.client = OpenAI()
-        if os.environ.get("OPENAI_API_BASE"):
-            self.client = OpenAI(base_url=os.environ.get("OPENAI_API_BASE"))
-        else:
-            if api_base:
-                self.client = OpenAI(base_url=api_base)
-            else:
-                self.client = OpenAI()
-
+    def __init__(self, what, is_en=False, api_base=None,api_key=None,model=None):
+        
+        self.client = OpenAI(base_url=api_base, api_key=api_key)
+        
+        self.model = model
         self.what = what
         self.is_en = is_en
         self.what_prompt = """
@@ -40,7 +35,7 @@ class What:
 
     def _to_what(self):
         completion = self.client.chat.completions.create(
-            model="gpt-3.5-turbo",
+            model=self.model,
             messages=[{"role": "user", "content": self.what_prompt}],
         )
         return completion.choices[0].message.content.encode("utf8").decode()


### PR DESCRIPTION
## 增加model参数

因为程序是支持修改接口url的，所以添加model的选项可以更好的支持非OpenAI的大模型。

如果不指定model，默认为：gpt-3.5-turbo

## 问题修复
### 修改openai版本
当前的版本直接运行会出现这个问题
![image](https://github.com/user-attachments/assets/dc91eaeb-69a6-49ae-aa93-0c981e659efe)

有两种解决办法：
1. 将httpx版本降低为：0.27.2 
2. 修改openai的版本号 >=1.56.0

### 修改Readme文件描述错误
根据代码所示，第三方的url的系统变量应为 OPENAI_API_BASE 而不是 OPENAI_BASE_URL